### PR TITLE
php 7.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/symfony": ">=2.0",
-        "spipu/html2pdf": "~4.5"
+        "spipu/html2pdf": "~5.2"
     },
     "require-dev": {
         "sensio/framework-extra-bundle": "~3.0"


### PR DESCRIPTION
Got this error : `Warning: count(): Parameter must be an array or an object that implements Countable`
Corrected in V5 of html2pdf, see : 
- https://github.com/spipu/html2pdf/issues/287
- https://github.com/spipu/html2pdf/releases/tag/v5.1.0